### PR TITLE
`console.log` 못 쓰게 하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
       "prettier/react"
     ],
     "rules": {
+      "no-console": "warn",
       "react/jsx-uses-react": "off",
       "react/react-in-jsx-scope": "off"
     }


### PR DESCRIPTION
이거 머지 하면 나중에 console.log 쓰면 경고 날거야.

![image](https://user-images.githubusercontent.com/3399854/103253464-aa07fd00-49c4-11eb-8c83-b7ac5d860b36.png)
