### PR TITLE
window.location.reload 테스트 이슈 해결

### DIFF
--- a/src/components/MatchDetail.test.tsx
+++ b/src/components/MatchDetail.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import MatchDetail from "./MatchDetail";
 import firebase from "firebase";
-import { fireAntEvent } from "../setupTests";
+import { fireAntEvent, mockWindowLocationReload } from "../setupTests";
 
 describe("Test", () => {
   beforeEach(() => {
@@ -66,11 +66,7 @@ describe("Test", () => {
 
     window.alert = () => "";
     window.confirm = () => true;
-    //Error: Not implemented: navigation (except hash changes) 발생
-    //현재 해결할 수 있는 방법은 delete 한 다음에 다시 reload 생성하는 것
-    //https://remarkablemark.org/blog/2018/11/17/mock-window-location/ 참고
-    delete window.location;
-    window.location = { reload: jest.fn() };
+    mockWindowLocationReload();
 
     await fireAntEvent.actAndClick("예약취소");
     const { status } = firebase
@@ -176,11 +172,7 @@ describe("Test", () => {
 
     window.alert = () => "";
     window.confirm = () => true;
-    //Error: Not implemented: navigation (except hash changes) 발생
-    //현재 해결할 수 있는 방법은 delete 한 다음에 다시 reload 생성하는 것
-    //https://remarkablemark.org/blog/2018/11/17/mock-window-location/ 참고
-    delete window.location;
-    window.location = { reload: jest.fn() };
+    mockWindowLocationReload();
 
     render(<MatchDetail />);
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -68,3 +68,11 @@ export const fireAntEvent = {
     });
   },
 };
+
+export function mockWindowLocationReload(): void {
+  //Error: Not implemented: navigation (except hash changes) 발생
+  //현재 해결할 수 있는 방법은 delete 한 다음에 다시 reload 생성하는 것
+  //https://remarkablemark.org/blog/2018/11/17/mock-window-location/ 참고
+  delete window.location;
+  window.location = { reload: jest.fn() };
+}


### PR DESCRIPTION
머지한다음에 window.location.reload() 테스트에서 error: not implemented: navigation (except hash changes) 에러가 발생해
저번처럼 브라우저랑 테스트가 환경이 달라서 발생하는 에러같아.
해결책 찾아봤는데 "The new solution is to delete location and recreate reload as a mock:" 이렇게 있어서
delete window.location.reload 하고 window.location.reload mock 했어 

밑에 블로그 참고했어
https://remarkablemark.org/blog/2018/11/17/mock-window-location/ 

그리고 에러 화면은 이렇게 돼! 혹시 더 좋은 방안 있으면 바꿔볼게 
![image](https://user-images.githubusercontent.com/47590587/107118087-247c4480-68c2-11eb-9052-86222728fd92.png)
