### PR TITLE
헤더 메뉴 about -> dm, 카카오 링크 연결

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -16,6 +16,9 @@
 .selectedMenu {
   border-bottom: 1px solid var(--orange-color);
 }
+.dm {
+  color: var(--white-color);
+}
 .signin {
   display: flex;
   justify-content: flex-end;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -85,7 +85,14 @@ const Header = (): JSX.Element => {
         </Col>
         <Col span={8} className="menu">
           <div className="menuFirstItem selectedMenu">MATCH</div>
-          <div>ABOUT</div>
+          <a
+            className="dm"
+            href="http://pf.kakao.com/_vQNPK"
+            target="_blank"
+            rel="noreferrer"
+          >
+            DM
+          </a>
         </Col>
         <Col span={4}></Col>
         <Col span={4} className="signin">


### PR DESCRIPTION
클라이언트가 메뉴에서 About 말고 DM 추가하기 원해서 수정하고 카카오 링크 연결했어.
오픈전에 꼭 바꿔 달라고 부탁해서 먼저 작업했어! 용어도 꼭 DM 으로 해달라고 했어!

fixes #61 

![image](https://user-images.githubusercontent.com/47590587/107152598-1276d080-69ac-11eb-85be-00d9e1ffaa82.png)
