### PR TITLE
헤더 match 클릭시 메인페이지로 이동

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,7 +88,9 @@ const Header = (): JSX.Element => {
           </Link>
         </Col>
         <Col span={8} className="menu">
-          <div className="menuFirstItem selectedMenu">MATCH</div>
+          <Link to="/">
+            <div className="menuFirstItem selectedMenu">MATCH</div>
+          </Link>
           <a
             className="dm"
             href="http://pf.kakao.com/_vQNPK"


### PR DESCRIPTION
헤더에서 로고 클릭하면 메인페이지로 가는데
match 클릭하면 메인페이지 연결 안되있어서 추가했어!

fixes #54 