### PR TITLE
매치리스트 링크 속성때문에 색상 바뀌는거 수정

### DIFF
--- a/src/components/MatchListItem.css
+++ b/src/components/MatchListItem.css
@@ -4,9 +4,11 @@
   margin-bottom: 10px;
 }
 .time {
+  color: var(--black-color);
   font-size: 18px;
 }
 .place {
+  color: var(--black-color);
   font-size: 14px;
   margin-bottom: 4px;
 }


### PR DESCRIPTION
링크 속성때문에 매치리스트 색상이 파란색으로 바뀌어서 수정했어
css 적용했는데 더 좋은 방안 있으면 알려줘!

![image](https://user-images.githubusercontent.com/47590587/107732321-692d3300-6d3b-11eb-81f9-56c867f51fff.png)
