### PR TITLE
disallow unused vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "prettier/react"
     ],
     "rules": {
+      "@typescript-eslint/no-unused-vars": "error",
       "no-console": "warn",
       "react/jsx-uses-react": "off",
       "react/react-in-jsx-scope": "off"


### PR DESCRIPTION
필요 없는 변수나 import있으면 오류 나게 해.

이런 상황 피하고 싶어:
![image](https://user-images.githubusercontent.com/3399854/107941862-bd4f4600-6fcd-11eb-8a0b-38b3938e5954.png)
