### PR TITLE
기획반일때 시작날짜로 한번 더 소팅해주기

### DIFF
--- a/src/components/MatchList.tsx
+++ b/src/components/MatchList.tsx
@@ -29,8 +29,18 @@ const MatchList = (props: { recurringClasses?: boolean }): JSX.Element => {
         .get();
 
       const dateKeyToMatches: Map<string, Match[]> = new Map();
+      const queryArray = recurringClasses //filter with an inequality 에러로 인하여 기획반일때 dateTime으로 한번더 소팅해주기
+        ? querySnapshot.docs.sort(
+            (
+              prevData: firebase.firestore.QueryDocumentSnapshot<firebase.firestore.DocumentData>,
+              nextData: firebase.firestore.QueryDocumentSnapshot<firebase.firestore.DocumentData>
+            ) => {
+              return prevData.data().dateTime - nextData.data().dateTime;
+            }
+          )
+        : querySnapshot.docs;
 
-      querySnapshot.docs.forEach((doc) => {
+      queryArray.forEach((doc) => {
         const data = doc.data();
         data.dateTime = data.dateTime.toDate();
         data.id = doc.id;


### PR DESCRIPTION
[ 문제점 ]
firebase 쿼리 제한 사항 때문에 기획반인 경우 orderBy는 endDate로 밖에 할 수 없어서 시작날짜로 정렬하려면 별도의 sorting이 필요함.

[ 해결방법]
firebase로 데이터 가져올때는 endDate로 정렬하고 Array.sort 함수 이용하여 dateTime으로 한번 더 정렬 

참고문서
https://cloud.google.com/firestore/docs/query-data/queries